### PR TITLE
Allow hyphens in Natwest sort code

### DIFF
--- a/forms/natwest.html
+++ b/forms/natwest.html
@@ -49,7 +49,7 @@
           <label for="sortcode">Their sort code</label>
           <div class="row">
             <div class="col-sm-3">
-              <input type="text" name="sortcode" id="sortcode" class="form-control" maxlength="6" pattern="[0-9]{6}" title="Must be 6 numbers">
+              <input type="text" name="sortcode" id="sortcode" class="form-control" maxlength="8" pattern="[0-9-]{8}" title="Must be 8 numbers or dashes">
             </div>
           </div>
         </div>

--- a/summary.html
+++ b/summary.html
@@ -60,7 +60,7 @@
     if (getParameterByName('sortcode-1')) {
       val = getParameterByName('sortcode-1') + getParameterByName('sortcode-2') + getParameterByName('sortcode-3');
     }
-    val = val.match(/.{1,2}/g).join('-');
+    val = val.replace(/-/g, '').match(/.{1,2}/g).join('-');
   }
 
   if (name === 'amount') {


### PR DESCRIPTION
Sort code for Natwest is a single field and does not specify length. This change allows up to 8 characters in the field which can be digits or hyphens. This means a sort code with hyphens can be pasted into the field.
